### PR TITLE
Change delimiter

### DIFF
--- a/openapi/templates/README.mustache
+++ b/openapi/templates/README.mustache
@@ -56,7 +56,7 @@ namespace MyProject
         static void Main(string[] args)
         {
             Configuration config = new Configuration();
-            config.DefaultHeaders = new Dictionary<string, string>{{ "Accept", "application/vnd.mx.api.v1+json" }};
+            config.DefaultHeaders = new Dictionary<string, string>{{=<% %>=}}{{<%={{ }}=%> "Accept", "application/vnd.mx.api.v1+json" }};
 
             // Configure with your Client ID/API Key from https://dashboard.mx.com
             config.Username = "Your Client ID";


### PR DESCRIPTION
Changes delimiter temporarily to escape Mustache's `{{` so that the
Accept header appears in the README example.