### PR TITLE
Add dictionary

### DIFF
--- a/openapi/templates/README.mustache
+++ b/openapi/templates/README.mustache
@@ -48,6 +48,7 @@ using System;
 using MX.Platform.CSharp.Api;
 using MX.Platform.CSharp.Client;
 using MX.Platform.CSharp.Model;
+using System.Collections.Generic;
 
 namespace MyProject
 {


### PR DESCRIPTION
Adds `using System.Collections.Generic;` so that we can use the
dictionary when setting the Accept header.