### PR TITLE
Use latest openapi-generator version

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Install openapi-generator-cli
       run: |
         npm install @openapitools/openapi-generator-cli -g
-        openapi-generator-cli version-manager set 5.4.0
     - run: |
         openapi-generator-cli generate \
           -i https://raw.githubusercontent.com/mxenabled/openapi/master/openapi/mx_platform_api.yml \

--- a/.github/workflows/generate_publish_release.yml
+++ b/.github/workflows/generate_publish_release.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Install openapi-generator-cli
         run: |
           npm install @openapitools/openapi-generator-cli -g
-          openapi-generator-cli version-manager set 5.4.0
       - run: |
           openapi-generator-cli generate \
             -i https://raw.githubusercontent.com/mxenabled/openapi/master/openapi/mx_platform_api.yml \

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,7 +1,4 @@
 {
   "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
-  "spaces": 2,
-  "generator-cli": {
-    "version": "5.4.0"
-  }
+  "spaces": 2
 }


### PR DESCRIPTION
Use the latest `openapi-generator-cli` version when generating the library to help resolve current bugs and mitigate future bugs.